### PR TITLE
Add support for Packer remote plugin docs

### DIFF
--- a/.docs-artifacts/builders/exoscale.mdx
+++ b/.docs-artifacts/builders/exoscale.mdx
@@ -1,0 +1,116 @@
+---
+description: >
+  The exoscale builder is used to create Exoscale custom templates based on a Compute instance snapshot.
+page_title: Exoscale - Builders
+sidebar_title: Exoscale
+---
+
+# Exoscale Builder
+
+Type: `exoscale`
+
+The `exoscale` builder is used to create Exoscale custom templates based on a
+Compute instance snapshot.
+
+**Note:** the `exoscale` Packer plugin only supports UNIX-like operating
+systems (e.g. GNU/Linux, \*BSD...). To build Exoscale custom templates for
+other OS, we recommend using the [QEMU][packerqemu] plugin combined with the
+[exoscale-import][exoscale-import] Packer post-processor plugin.
+
+
+### Required
+
+- `api_key` (string) - The API key used to communicate with Exoscale services.
+
+- `api_secret` (string) - The API secret used to communicate with Exoscale
+  services.
+
+- `instance_template` (string) - The name of the template to use when creating
+  the Compute instance.
+
+- `template_zone` (string) - The Exoscale [zone][zones] in which to create the
+  template.
+
+- `template_name` (string) - The name of the template.
+
+
+### Optional
+
+- `api_endpoint` (string) - The API endpoint used to communicate with the
+  Exoscale API. Defaults to `https://api.exoscale.com/v1`.
+
+- `instance_type` (string) - The instance type of the Compute instance.
+  Defaults to `Medium`.
+
+- `instance_name` (string) - The name of the Compute instance.
+  Defaults to `packer-<BUILD ID>`.
+
+- `instance_zone` (string) - The Exoscale zone in which to create the Compute
+  instance. Defaults to the value of `template_zone`.
+
+- `instance_template_filter` (string) - The template filter to specify for the
+  `instance_template` parameter. Defaults to `featured`.
+
+- `instance_disk_size` (int) - Volume disk size in GB of the Compute instance
+  to create. Defaults to `50`.
+
+- `instance_security_groups` (list of strings) - List of Security Groups
+  (names) to apply to the Compute instance. Defaults to `["default"]`.
+
+- `instance_private_networks` (list of strings) - List of Private Networks
+  (names) to attach to the Compute instance.
+
+- `instance_ssh_key` (string) - Name of the Exoscale SSH key to use with the
+  Compute instance. If unset, a throwaway SSH key named `packer-<BUILD ID>`
+  will be created before creating the instance, and destroyed after a
+  successful build.
+
+- `template_description` (string) - The description of the template.
+
+- `template_username` (string) - An optional username to be used to log into
+  Compute instances using this template.
+
+- `template_boot_mode` (string) - The template boot mode. Supported values:
+  `legacy` (default), `uefi`.
+
+- `template_disable_password` (boolean) - Whether the template should disable
+  Compute instance password reset. Defaults to `false`.
+
+- `template_disable_sshkey` (boolean) - Whether the template should disable
+  SSH key installation during Compute instance creation. Defaults to `false`.
+
+In addition to plugin-specific configuration parameters, you can also adjust
+the [SSH communicator][packerssh] settings to configure how Packer will log
+into the Compute instance.
+
+
+### Example Usage
+
+```hcl
+variable "api_key" { default = "" }
+variable "api_secret" { default = "" }
+
+source "exoscale" "my-app" {
+  api_key = var.api_key
+  api_secret = var.api_secret
+  instance_template = "Linux Ubuntu 20.04 LTS 64-bit"
+  instance_security_groups = ["packer"]
+  template_zone = "ch-gva-2"
+  template_name = "my-app"
+  template_username = "ubuntu"
+  ssh_username = "ubuntu"
+}
+
+build {
+  sources = ["source.exoscale.test"]
+
+  provisioner "shell" {
+    execute_command = "chmod +x {{.Path}}; sudo {{.Path}}"
+    scripts = ["install.sh"]
+  }
+}
+```
+
+
+[packerssh]: https://www.packer.io/docs/communicators/ssh/
+[zones]: https://www.exoscale.com/datacenters/

--- a/.docs-artifacts/builders/nav-data.json
+++ b/.docs-artifacts/builders/nav-data.json
@@ -1,0 +1,6 @@
+[
+  {
+    "path": "exoscale",
+    "filePath": "exoscale.mdx"
+  }
+]

--- a/.docs-artifacts/post-processors/exoscale-import.mdx
+++ b/.docs-artifacts/post-processors/exoscale-import.mdx
@@ -1,0 +1,129 @@
+---
+description: >
+  The exoscale-import post-processor is used to import Exoscale custom templates from disk image files.
+page_title: Scaffolding - Post-Processors
+sidebar_title: Exoscale
+---
+
+# Exoscale Import Post-processor
+
+Type: `exoscale-import`
+
+The `exoscale-import` post-processor is used to import Exoscale custom
+templates from disk image files (supported formats: `QCOW2`), e.g. an artifact
+built locally by the [`qemu`][packer-doc-builder-qemu] builder.
+
+
+### Required
+
+- `api_key` (string) - The API key used to communicate with Exoscale
+  services.
+
+- `api_secret` (string) - The API secret used to communicate with Exoscale
+  services.
+  
+- `image_bucket` (string) - The name of the bucket in which to upload the
+  template image to SOS. The bucket must exist when the post-processor is
+  run.
+
+- `template_zone` (string) - The Exoscale [zone][zones] in which to register
+  the template.
+
+- `template_name` (string) - The name to be used for registering the template.
+
+
+### Optional
+
+- `api_endpoint` (string) - The API endpoint used to communicate with the
+  Exoscale API. Defaults to `https://api.exoscale.com/v1`.
+
+- `sos_endpoint` (string) - The endpoint used to communicate with SOS.
+  Defaults to `https://sos-<template_zone>.exo.io`.
+
+- `template_description` (string) - The description of the registered template.
+
+- `template_username` (string) - An optional username to be used to log into
+  Compute instances using this template.
+
+- `template_boot_mode` (string) - The template boot mode.
+  Supported values: `legacy` (default), `uefi`.
+
+- `template_disable_password` (boolean) - Whether the registered template
+  should disable Compute instance password reset. Defaults to `false`.
+
+- `template_disable_sshkey` (boolean) - Whether the registered template
+  should disable SSH key installation during Compute instance creation.
+  Defaults to `false`.
+
+- `skip_clean` (boolean) - Whether we should skip removing the image file
+  uploaded to SOS after the import process has completed. "true" means that
+  we should leave it in the bucket, "false" means deleting it.
+  Defaults to `false`.
+
+
+### Example Usage
+
+```hcl
+variable "api_key" { default = "" }
+variable "api_secret" { default = "" }
+variable "exoscale_zone" { default = "ch-gva-2" }
+
+locals {
+  image_name        = "base"
+  image_format      = "qcow2"
+  image_output_dir  = "output-qemu"
+  image_username    = "ubuntu"
+  image_output_file = "${local.image_output_dir}/${local.image_name}.${local.image_format}"
+}
+
+source "qemu" "base" {
+  qemuargs = [
+    ["-drive", "file=${local.image_output_file},format=${local.image_format},if=virtio"],
+    ["-drive", "file=seed.img,format=raw,if=virtio"]
+  ]
+  cpus                  = 4
+  memory                = 4096
+  vm_name               = "${local.image_name}.${local.image_format}"
+  iso_url               = "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
+  iso_checksum_url      = "https://cloud-images.ubuntu.com/focal/current/SHA256SUMS"
+  iso_checksum_type     = "sha256"
+  format                = local.image_format
+  output_directory      = local.image_output_dir
+  
+  # ...
+}
+
+build {
+  sources = ["source.qemu.base"]
+  
+  provisioner "shell" {
+    environment_vars = ["DEBIAN_FRONTEND=noninteractive"]
+    inline = [
+      "sudo apt-get update && sudo apt-get upgrade -y",
+      "sudo apt-get install --no-install-recommends -y ansible",
+    ]
+  }
+}
+
+source "file" "base" {
+  source = local.image_output_file
+  target = "${local.image_name}.${local.image_format}"
+}
+
+build {
+  sources = ["source.file.base"]
+
+  post-processor "exoscale-import" {
+    api_key                 = var.exoscale_api_key
+    api_secret              = var.exoscale_api_secret
+    image_bucket            = "my-templates-${var.exoscale_zone}"
+    template_zone           = var.exoscale_zone
+    template_name           = local.image_name
+    template_username       = local.image_username
+  }
+}
+```
+
+
+[packer-doc-builder-qemu]: https://www.packer.io/docs/builders/qemu
+[zones]: https://www.exoscale.com/datacenters/

--- a/.docs-artifacts/post-processors/nav-data.json
+++ b/.docs-artifacts/post-processors/nav-data.json
@@ -1,0 +1,6 @@
+[
+  {
+    "path": "exoscale-import",
+    "filePath": "exoscale-import.mdx"
+  }
+]


### PR DESCRIPTION
Hi there :wave: a fellow Packer maintainer here to inform you about our new remote docs setup. I've been working on merging in a few exoscale changes with @falzm so I thought it would help to create a PR over an issue. 

This change adds a `.docs-artifacts` configuration that can be used for publishing remote plugin docs to Packer.io. This process will allow users to find and browse the content of remote plugins from Packer's main website, which they can then install by running `packer init`.

Details on this process can be found at
https://github.com/hashicorp/packer-plugin-scaffolding#registering-documentation-on-packerio

Once merged a small PR needs to be opened against hashicorp/packer to include the documentation in the website build. I've created https://github.com/hashicorp/packer/pull/10709 which includes the needed changes to pull in the remove docs once this PR has been merged. 

For the future, we recommend the use of the GitHub action which is no in the [packer-plugin-scaffolding](https://github.com/hashicorp/packer-plugin-scaffolding/blob/main/.github/workflows/generate-docs-artifacts.yml) repo to automatically update the .docs-artifacts directory when a new release is cut.

Here is an example of the Docker post-processors which are being pulled in remotely https://packer-9qi5zltix-hashicorp.vercel.app/docs/post-processors/docker/docker-import