### PR TITLE
Allow empty descriptions and usernames

### DIFF
--- a/builder/exoscale/step_register_template.go
+++ b/builder/exoscale/step_register_template.go
@@ -30,13 +30,13 @@ func (s *stepRegisterTemplate) Run(ctx context.Context, state multistep.StateBag
 		s.builder.config.TemplateZone,
 		&egoscale.Template{
 			BootMode:        &s.builder.config.TemplateBootMode,
-			Checksum:        &snapshotChecksum,
-			DefaultUser:     &s.builder.config.TemplateUsername,
-			Description:     &s.builder.config.TemplateDescription,
+			Checksum:        nonEmptyStringPtr(snapshotChecksum),
+			DefaultUser:     nonEmptyStringPtr(s.builder.config.TemplateUsername),
+			Description:     nonEmptyStringPtr(s.builder.config.TemplateDescription),
 			Name:            &s.builder.config.TemplateName,
 			PasswordEnabled: &passwordEnabled,
 			SSHKeyEnabled:   &sshkeyEnabled,
-			URL:             &snapshotURL,
+			URL:             nonEmptyStringPtr(snapshotURL),
 		},
 	)
 	if err != nil {

--- a/builder/exoscale/step_register_template_test.go
+++ b/builder/exoscale/step_register_template_test.go
@@ -64,3 +64,59 @@ func (ts *testSuite) TestStepRegisterTemplate_Run() {
 	ts.Require().Equal(stepAction, multistep.ActionContinue)
 	ts.Require().Equal(testTemplate, ts.state.Get("template"))
 }
+
+func (ts *testSuite) TestStepRegisterTemplateWithEmptyFields_Run() {
+	var (
+		testConfig = Config{
+			TemplateZone:        testZone,
+			TemplateName:        ts.randomString(10),
+			TemplateDescription: "",
+			TemplateUsername:    "",
+			TemplateBootMode:    ts.randomString(10),
+		}
+		testTemplatePasswordEnabled = !testConfig.TemplateDisablePassword
+		testTemplateSSHKeyEnabled   = !testConfig.TemplateDisableSSHKey
+		testSnapshotChecksum        = ts.randomString(32)
+		testSnapshotPresignedURL    = ts.randomString(100)
+		templateRegistered          bool
+	)
+
+	testTemplate := &egoscale.Template{
+		BootMode:        &testConfig.TemplateBootMode,
+		Checksum:        &testSnapshotChecksum,
+		DefaultUser:     nil,
+		Description:     nil,
+		Name:            &testConfig.TemplateName,
+		PasswordEnabled: &testTemplatePasswordEnabled,
+		SSHKeyEnabled:   &testTemplateSSHKeyEnabled,
+		URL:             &testSnapshotPresignedURL,
+	}
+	ts.state.Put("snapshot_checksum", testSnapshotChecksum)
+	ts.state.Put("snapshot_url", testSnapshotPresignedURL)
+
+	ts.exo.(*exoscaleClientMock).
+		On(
+			"RegisterTemplate",
+			mock.Anything, // ctx
+			testZone,      // zone
+			mock.Anything, // template
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(testTemplate, args.Get(2))
+			templateRegistered = true
+		}).
+		Return(testTemplate, nil)
+
+	stepAction := (&stepRegisterTemplate{
+		builder: &Builder{
+			buildID: ts.randomID(),
+			config:  &testConfig,
+			exo:     ts.exo,
+		},
+	}).
+		Run(context.Background(), ts.state)
+	ts.Require().True(templateRegistered)
+	ts.Require().Empty(ts.ui.(*packer.MockUi).ErrorMessage)
+	ts.Require().Equal(stepAction, multistep.ActionContinue)
+	ts.Require().Equal(testTemplate, ts.state.Get("template"))
+}

--- a/builder/exoscale/util.go
+++ b/builder/exoscale/util.go
@@ -1,0 +1,9 @@
+package exoscale
+
+func nonEmptyStringPtr(s string) *string {
+	if s != "" {
+		return &s
+	}
+
+	return nil
+}

--- a/post-processor/exoscale-import/step_register_template.go
+++ b/post-processor/exoscale-import/step_register_template.go
@@ -29,24 +29,14 @@ func (s *stepRegisterTemplate) Run(ctx context.Context, state multistep.StateBag
 		ctx,
 		s.postProcessor.config.TemplateZone,
 		&egoscale.Template{
-			BootMode: &s.postProcessor.config.TemplateBootMode,
-			Checksum: &imageChecksum,
-			DefaultUser: func() (v *string) {
-				if s.postProcessor.config.TemplateUsername != "" {
-					v = &s.postProcessor.config.TemplateUsername
-				}
-				return
-			}(),
-			Description: func() (v *string) {
-				if s.postProcessor.config.TemplateDescription != "" {
-					v = &s.postProcessor.config.TemplateDescription
-				}
-				return
-			}(),
+			BootMode:        &s.postProcessor.config.TemplateBootMode,
+			Checksum:        nonEmptyStringPtr(imageChecksum),
+			DefaultUser:     nonEmptyStringPtr(s.postProcessor.config.TemplateUsername),
+			Description:     nonEmptyStringPtr(s.postProcessor.config.TemplateDescription),
 			Name:            &s.postProcessor.config.TemplateName,
 			PasswordEnabled: &passwordEnabled,
 			SSHKeyEnabled:   &sshkeyEnabled,
-			URL:             &imageURL,
+			URL:             nonEmptyStringPtr(imageURL),
 		})
 	if err != nil {
 		ui.Error(fmt.Sprintf("unable to export Compute instance snapshot: %s", err))

--- a/post-processor/exoscale-import/step_register_template_test.go
+++ b/post-processor/exoscale-import/step_register_template_test.go
@@ -63,3 +63,58 @@ func (ts *testSuite) TestStepRegisterTemplate_Run() {
 	ts.Require().Equal(stepAction, multistep.ActionContinue)
 	ts.Require().Equal(testTemplate, ts.state.Get("template"))
 }
+
+func (ts *testSuite) TestStepRegisterTemplateWithEmptyFields_Run() {
+	var (
+		testConfig = Config{
+			TemplateZone:        testZone,
+			TemplateName:        ts.randomString(10),
+			TemplateDescription: "",
+			TemplateUsername:    "",
+			TemplateBootMode:    ts.randomString(10),
+		}
+		testTemplatePasswordEnabled = !testConfig.TemplateDisablePassword
+		testTemplateSSHKeyEnabled   = !testConfig.TemplateDisableSSHKey
+		testSnapshotChecksum        = ts.randomString(32)
+		testSnapshotPresignedURL    = ts.randomString(100)
+		templateRegistered          bool
+	)
+
+	testTemplate := &egoscale.Template{
+		BootMode:        &testConfig.TemplateBootMode,
+		Checksum:        &testSnapshotChecksum,
+		DefaultUser:     nil,
+		Description:     nil,
+		Name:            &testConfig.TemplateName,
+		PasswordEnabled: &testTemplatePasswordEnabled,
+		SSHKeyEnabled:   &testTemplateSSHKeyEnabled,
+		URL:             &testSnapshotPresignedURL,
+	}
+	ts.state.Put("image_checksum", testSnapshotChecksum)
+	ts.state.Put("image_url", testSnapshotPresignedURL)
+
+	ts.exo.(*exoscaleClientMock).
+		On(
+			"RegisterTemplate",
+			mock.Anything, // ctx
+			testZone,      // zone
+			mock.Anything, // template
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(testTemplate, args.Get(2))
+			templateRegistered = true
+		}).
+		Return(testTemplate, nil)
+
+	stepAction := (&stepRegisterTemplate{
+		postProcessor: &PostProcessor{
+			config: &testConfig,
+			exo:    ts.exo,
+		},
+	}).
+		Run(context.Background(), ts.state)
+	ts.Require().True(templateRegistered)
+	ts.Require().Empty(ts.ui.(*packer.MockUi).ErrorMessage)
+	ts.Require().Equal(stepAction, multistep.ActionContinue)
+	ts.Require().Equal(testTemplate, ts.state.Get("template"))
+}

--- a/post-processor/exoscale-import/util.go
+++ b/post-processor/exoscale-import/util.go
@@ -1,0 +1,9 @@
+package exoscaleimport
+
+func nonEmptyStringPtr(s string) *string {
+	if s != "" {
+		return &s
+	}
+
+	return nil
+}


### PR DESCRIPTION
Tests:
```
➜ make test-acc     
PACKER_ACC=1 /usr/local/go/bin/go test         \
        -race                       \
        -timeout 60m                \
        --tags=testacc              \
        -v -parallel 3 -count=1 -failfast       \
        github.com/exoscale/packer-plugin-exoscale/builder/exoscale github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import
=== RUN   TestAccBuilder
2022/02/01 12:18:56 ui: Build ID: c7she82967tktn99hih0
2022/02/01 12:18:56 ui: Creating SSH key
2022/02/01 12:18:56 ui: Creating Compute instance
2022/02/01 12:19:10 ui: Using SSH communicator to connect: 185.19.29.88
2022/02/01 12:19:10 [INFO] Waiting for SSH, up to timeout: 5m0s
2022/02/01 12:19:10 ui: Waiting for SSH to become available...
2022/02/01 12:19:25 [DEBUG] TCP connection to SSH ip/port failed: dial tcp 185.19.29.88:22: i/o timeout
2022/02/01 12:19:30 [INFO] Attempting SSH connection to 185.19.29.88:22...
2022/02/01 12:19:30 [DEBUG] reconnecting to TCP connection for SSH
2022/02/01 12:19:30 [DEBUG] handshaking with SSH
2022/02/01 12:19:31 [DEBUG] handshake complete!
2022/02/01 12:19:31 [DEBUG] Opening new ssh session
2022/02/01 12:19:32 [INFO] agent forwarding enabled
2022/02/01 12:19:32 ui: Connected to SSH!
2022/02/01 12:19:32 Running the provision hook
2022/02/01 12:19:32 ui: Stopping Compute instance
2022/02/01 12:19:38 ui: Creating Compute instance snapshot
2022/02/01 12:20:03 ui: Exporting Compute instance snapshot
2022/02/01 12:20:07 ui: Registering Compute instance template
2022/02/01 12:21:13 ui: Cleanup: destroying Compute instance
2022/02/01 12:21:20 ui: Cleanup: deleting SSH key
--- PASS: TestAccBuilder (150.29s)
=== RUN   TestSuiteExoscaleBuilder
=== RUN   TestSuiteExoscaleBuilder/TestArtifact_Destroy
=== RUN   TestSuiteExoscaleBuilder/TestBuilder_Prepare
=== RUN   TestSuiteExoscaleBuilder/TestBuilder_Prepare/fail_missing_required_config_args
=== RUN   TestSuiteExoscaleBuilder/TestBuilder_Prepare/ok
=== RUN   TestSuiteExoscaleBuilder/TestNewConfig
=== RUN   TestSuiteExoscaleBuilder/TestStepCreateInstance_Cleanup
=== RUN   TestSuiteExoscaleBuilder/TestStepCreateInstance_Run
=== RUN   TestSuiteExoscaleBuilder/TestStepCreateSSHKey_Cleanup
=== RUN   TestSuiteExoscaleBuilder/TestStepCreateSSHKey_Run
=== RUN   TestSuiteExoscaleBuilder/TestStepExportSnapshot_Run
=== RUN   TestSuiteExoscaleBuilder/TestStepRegisterTemplateWithEmptyFields_Run
=== RUN   TestSuiteExoscaleBuilder/TestStepRegisterTemplate_Run
=== RUN   TestSuiteExoscaleBuilder/TestStepSnapshotInstance_Run
=== RUN   TestSuiteExoscaleBuilder/TestStepStopInstance_Run
--- PASS: TestSuiteExoscaleBuilder (0.02s)
    --- PASS: TestSuiteExoscaleBuilder/TestArtifact_Destroy (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestBuilder_Prepare (0.00s)
        --- PASS: TestSuiteExoscaleBuilder/TestBuilder_Prepare/fail_missing_required_config_args (0.00s)
        --- PASS: TestSuiteExoscaleBuilder/TestBuilder_Prepare/ok (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestNewConfig (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestStepCreateInstance_Cleanup (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestStepCreateInstance_Run (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestStepCreateSSHKey_Cleanup (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestStepCreateSSHKey_Run (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestStepExportSnapshot_Run (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestStepRegisterTemplateWithEmptyFields_Run (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestStepRegisterTemplate_Run (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestStepSnapshotInstance_Run (0.00s)
    --- PASS: TestSuiteExoscaleBuilder/TestStepStopInstance_Run (0.00s)
PASS
ok      github.com/exoscale/packer-plugin-exoscale/builder/exoscale     150.377s
=== RUN   TestNewConfig
--- PASS: TestNewConfig (0.00s)
=== RUN   TestAccPostProcessor
2022/02/01 12:18:56 ui: Uploading template image
2022/02/01 12:18:56 ui: Registering Compute instance template
2022/02/01 12:19:00 ui: Deleting uploaded template image
--- PASS: TestAccPostProcessor (7.44s)
=== RUN   TestSuiteExoscaleImportPostProcessor
=== RUN   TestSuiteExoscaleImportPostProcessor/TestArtifact_Destroy
=== RUN   TestSuiteExoscaleImportPostProcessor/TestStepRegisterTemplateWithEmptyFields_Run
=== RUN   TestSuiteExoscaleImportPostProcessor/TestStepRegisterTemplate_Run
=== RUN   TestSuiteExoscaleImportPostProcessor/TestStepUploadImage_Cleanup
=== RUN   TestSuiteExoscaleImportPostProcessor/TestStepUploadImage_Run
--- PASS: TestSuiteExoscaleImportPostProcessor (0.02s)
    --- PASS: TestSuiteExoscaleImportPostProcessor/TestArtifact_Destroy (0.00s)
    --- PASS: TestSuiteExoscaleImportPostProcessor/TestStepRegisterTemplateWithEmptyFields_Run (0.00s)
    --- PASS: TestSuiteExoscaleImportPostProcessor/TestStepRegisterTemplate_Run (0.00s)
    --- PASS: TestSuiteExoscaleImportPostProcessor/TestStepUploadImage_Cleanup (0.00s)
    --- PASS: TestSuiteExoscaleImportPostProcessor/TestStepUploadImage_Run (0.00s)
PASS
ok      github.com/exoscale/packer-plugin-exoscale/post-processor/exoscale-import       7.514s
```