### PR TITLE
Makefile: add (un)install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ GO_BIN_OUTPUT_NAME := packer-plugin-exoscale
 API_VERSION := $(shell go run . describe | jq -r '.api_version')
 EXTRA_ARGS := -parallel 3 -count=1 -failfast
 
+PACKER_PLUGINS_DIR := $(HOME)/.packer.d/plugins
+
 # Dependencies
 
 # Requires: https://github.com/exoscale/go.mk
@@ -53,6 +55,19 @@ test-acc: ## Runs acceptance tests (requires valid Exoscale API credentials)
 	  --tags=testacc \
 	  $(GO_TEST_EXTRA_ARGS) \
 	  $(GO_TEST_PKGS)
+
+# Install (locally)
+
+$(PACKER_PLUGINS_DIR):
+	mkdir -p '$(PACKER_PLUGINS_DIR)'
+
+.PHONY: install
+install $(PACKER_PLUGINS_DIR)/$(GO_BIN_OUTPUT_NAME): $(GO_BIN_OUTPUT_DIR)/$(GO_BIN_OUTPUT_NAME) $(PACKER_PLUGINS_DIR)
+	cp -v '$(GO_BIN_OUTPUT_DIR)/$(GO_BIN_OUTPUT_NAME)' '$(PACKER_PLUGINS_DIR)/$(GO_BIN_OUTPUT_NAME)'
+
+.PHONY: uninstall
+uninstall:
+	rm -fv "$${HOME}/.packer.d/plugins/$(GO_BIN_OUTPUT_NAME)"
 
 # Release
 


### PR DESCRIPTION
(handy for test/development purposes)

Requires: https://github.com/exoscale/go.mk/pull/25

## Testing done

```
* [go-1.18] cdufour@xps13-9380.cedric.exoscale.me:~/git/exoscale/packer-plugin-exoscale (cedric/sc-34540/makefile-local-install)
$ git submodule status -- go.mk
+7acdea916c54938b6f85575623e240b787e10cba go.mk (remotes/origin/cedric/not-phony)

$ make clean
rm -rf '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/coverage'
rm -rf '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin'
rm -f 'packer-plugin-exoscale'

$ make install
mkdir -p '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin'
'/opt/cdufour/go/1.18/bin/go' build \
   \
  -ldflags "-X main.commit=bb66cf3 -X main.branch=cedric/sc-34540/makefile-local-install -X main.buildDate=2022-03-29T07:22:46+0000 -X main.version=dev " \
   \
  -mod vendor \
  -o '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin/packer-plugin-exoscale' \
  '.'
mkdir -p "${HOME}/.packer.d/plugins"
cp -v '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin/packer-plugin-exoscale' "${HOME}/.packer.d/plugins/packer-plugin-exoscale"
'/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin/packer-plugin-exoscale' -> '/home/cdufour/.packer.d/plugins/packer-plugin-exoscale'

$ make install
mkdir -p "${HOME}/.packer.d/plugins"
cp -v '/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin/packer-plugin-exoscale' "${HOME}/.packer.d/plugins/packer-plugin-exoscale"
'/local/data/encrypted/git/exoscale/packer-plugin-exoscale/bin/packer-plugin-exoscale' -> '/home/cdufour/.packer.d/plugins/packer-plugin-exoscale'

$ make /home/cdufour/.packer.d/plugins/packer-plugin-exoscale 
make: '/home/cdufour/.packer.d/plugins/packer-plugin-exoscale' is up to date.

$ make uninstall 
rm -fv "${HOME}/.packer.d/plugins/packer-plugin-exoscale"
removed '/home/cdufour/.packer.d/plugins/packer-plugin-exoscale'
@ 2022-03-29 09:23:19 +0200
```