### PR TITLE
Update documentation variable names

### DIFF
--- a/docs/post-processors/exoscale-import.md
+++ b/docs/post-processors/exoscale-import.md
@@ -63,8 +63,8 @@ built locally by the [`qemu`][packer-doc-builder-qemu] builder.
 ### Example Usage
 
 ```hcl
-variable "api_key" { default = "" }
-variable "api_secret" { default = "" }
+variable "exoscale_api_key" { default = "" }
+variable "exoscale_api_secret" { default = "" }
 variable "exoscale_zone" { default = "ch-gva-2" }
 
 locals {
@@ -112,8 +112,8 @@ build {
   sources = ["source.file.base"]
 
   post-processor "exoscale-import" {
-    api_key           = var.api_key
-    api_secret        = var.api_secret
+    api_key           = var.exoscale_api_key
+    api_secret        = var.exoscale_api_secret
     image_bucket      = "my-templates-${var.exoscale_zone}"
     template_zones    = [var.exoscale_zone]
     template_name     = local.image_name

--- a/docs/post-processors/exoscale-import.md
+++ b/docs/post-processors/exoscale-import.md
@@ -112,8 +112,8 @@ build {
   sources = ["source.file.base"]
 
   post-processor "exoscale-import" {
-    api_key           = var.exoscale_api_key
-    api_secret        = var.exoscale_api_secret
+    api_key           = var.api_key
+    api_secret        = var.api_secret
     image_bucket      = "my-templates-${var.exoscale_zone}"
     template_zones    = [var.exoscale_zone]
     template_name     = local.image_name


### PR DESCRIPTION
Hello Exoscale team,

I believe there is a mistake in the example script you provided and the "required" fields. 

Also, to have the same style of variables, I would remove the `exoscale_` from the ` exoscale_zone` or add it everywhere. Let me know if you want me to update the PR to reflect your decisions.