### PR TITLE
builder: use egoscale GetTemplateByName on instance creation

### DIFF
--- a/builder/exoscale/builder.go
+++ b/builder/exoscale/builder.go
@@ -41,6 +41,7 @@ type exoscaleClient interface {
 	FindPrivateNetwork(context.Context, string, string) (*egoscale.PrivateNetwork, error)
 	FindSecurityGroup(context.Context, string, string) (*egoscale.SecurityGroup, error)
 	GetTemplate(context.Context, string, string) (*egoscale.Template, error)
+	GetTemplateByName(context.Context, string, string, string) (*egoscale.Template, error)
 	ListTemplates(context.Context, string, ...egoscale.ListTemplatesOpt) ([]*egoscale.Template, error)
 	RegisterSSHKey(context.Context, string, string, string) (*egoscale.SSHKey, error)
 	RegisterTemplate(context.Context, string, *egoscale.Template) (*egoscale.Template, error)

--- a/builder/exoscale/builder_mock.go
+++ b/builder/exoscale/builder_mock.go
@@ -111,6 +111,16 @@ func (m *exoscaleClientMock) GetTemplate(ctx context.Context, zone string, id st
 	return args.Get(0).(*egoscale.Template), args.Error(1)
 }
 
+func (m *exoscaleClientMock) GetTemplateByName(
+	ctx context.Context,
+	zone string,
+	templateName string,
+	visibility string,
+) (*egoscale.Template, error) {
+	args := m.Called(ctx, zone, templateName, visibility)
+	return args.Get(0).(*egoscale.Template), args.Error(1)
+}
+
 func (m *exoscaleClientMock) ListTemplates(
 	ctx context.Context,
 	zone string,

--- a/builder/exoscale/step_create_instance.go
+++ b/builder/exoscale/step_create_instance.go
@@ -41,20 +41,17 @@ func (s *stepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 	template, _ := s.builder.exo.GetTemplate(ctx, s.builder.config.InstanceZone, s.builder.config.InstanceTemplate)
 
 	if template == nil {
-		templates, err := s.builder.exo.ListTemplates(
+
+		template, err = s.builder.exo.GetTemplateByName(
 			ctx,
 			s.builder.config.InstanceZone,
-			egoscale.ListTemplatesWithVisibility(s.builder.config.InstanceTemplateVisibility),
+			s.builder.config.InstanceTemplate,
+			s.builder.config.InstanceTemplateVisibility,
 		)
+
 		if err != nil {
-			ui.Error(fmt.Sprintf("Unable to list compute instance templates: %v", err))
+			ui.Error(fmt.Sprintf("Unable to fetch compute instance templates: %v", err))
 			return multistep.ActionHalt
-		}
-		for _, template = range templates {
-			if *template.ID == s.builder.config.InstanceTemplate ||
-				*template.Name == s.builder.config.InstanceTemplate {
-				break
-			}
 		}
 		if template == nil {
 			ui.Error(fmt.Sprintf(
@@ -63,12 +60,6 @@ func (s *stepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 				s.builder.config.InstanceTemplateVisibility,
 				s.builder.config.InstanceZone,
 			))
-			return multistep.ActionHalt
-		}
-
-		template, err = s.builder.exo.GetTemplate(ctx, s.builder.config.InstanceZone, *template.ID)
-		if err != nil {
-			ui.Error(fmt.Sprintf("Unable to retrieve compute instance template: %v", err))
 			return multistep.ActionHalt
 		}
 	}

--- a/builder/exoscale/step_create_instance_test.go
+++ b/builder/exoscale/step_create_instance_test.go
@@ -15,15 +15,16 @@ import (
 func (ts *testSuite) TestStepCreateInstance_Run() {
 	var (
 		testConfig = Config{
-			InstanceDiskSize:        defaultInstanceDiskSize,
-			InstanceName:            testInstanceName,
-			InstanceSSHKey:          ts.randomID(),
-			InstanceSecurityGroups:  []string{testInstanceSecurityGroupName},
-			InstancePrivateNetworks: []string{testInstancePrivateNetworkName},
-			InstanceTemplate:        testTemplateName,
-			InstanceType:            testInstanceTypeName,
-			InstanceZone:            testInstanceZone,
-			TemplateZones:           testTemplateZones,
+			InstanceDiskSize:           defaultInstanceDiskSize,
+			InstanceName:               testInstanceName,
+			InstanceSSHKey:             ts.randomID(),
+			InstanceSecurityGroups:     []string{testInstanceSecurityGroupName},
+			InstancePrivateNetworks:    []string{testInstancePrivateNetworkName},
+			InstanceTemplate:           testTemplateName,
+			InstanceTemplateVisibility: defaultInstanceTemplateVisibility,
+			InstanceType:               testInstanceTypeName,
+			InstanceZone:               testInstanceZone,
+			TemplateZones:              testTemplateZones,
 		}
 		instanceCreated                bool
 		instancePrivateNetworkAttached bool
@@ -65,22 +66,12 @@ func (ts *testSuite) TestStepCreateInstance_Run() {
 
 	ts.exo.(*exoscaleClientMock).
 		On(
-			"ListTemplates",
-			mock.Anything,    // ctx
-			testInstanceZone, // zone
-			mock.Anything,    // opts
+			"GetTemplateByName",
+			mock.Anything,                         // ctx
+			testInstanceZone,                      // zone
+			testTemplateName,                      // name
+			testConfig.InstanceTemplateVisibility, // visibility
 		).
-		Return([]*egoscale.Template{{
-			ID:   &testTemplateID,
-			Name: &testTemplateName,
-		}}, nil)
-
-	ts.exo.(*exoscaleClientMock).
-		On(
-			"GetTemplate",
-			mock.Anything,    // ctx
-			testInstanceZone, // zone
-			testTemplateID).  // x
 		Return(&egoscale.Template{ID: &testTemplateID}, nil)
 
 	ts.exo.(*exoscaleClientMock).


### PR DESCRIPTION
Employ egoscale's GetTemplateByName to fetch the desired template during instance creation step. The advantage is that said method will consider templates with same name and return the newest.