### PR TITLE
go.mk: remove submodule and initialize through make

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Checkout go.mk
-        run: git submodule update --init --recursive go.mk
+        run: make go.mk
       - uses: ./go.mk/.github/actions/setup
 
       - uses: ./go.mk/.github/actions/pre-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
         shell: bash
 
       - name: Import GPG key

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/go.mk
 main
 bin
 coverage

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "go.mk"]
-	path = go.mk
-	url = https://github.com/exoscale/go.mk.git

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,32 @@
+GO_MK_REF := v1.0.0
+
+# make go.mk a dependency for all targets
+.EXTRA_PREREQS = go.mk
+
+ifndef MAKE_RESTARTS
+# This section will be processed the first time that make reads this file.
+
+# This causes make to re-read the Makefile and all included
+# makefiles after go.mk has been cloned.
+Makefile:
+	@touch Makefile
+endif
+
+.PHONY: go.mk
+.ONESHELL:
+go.mk:
+	@if [ ! -d "go.mk" ]; then
+		git clone https://github.com/exoscale/go.mk.git
+	fi
+	@cd go.mk
+	@if ! git show-ref --quiet --verify "refs/heads/${GO_MK_REF}"; then
+		git fetch
+	fi
+	@if ! git show-ref --quiet --verify "refs/tags/${GO_MK_REF}"; then
+		git fetch --tags
+	fi
+	git checkout --quiet ${GO_MK_REF}
+
 ## Project
 
 PACKAGE := github.com/exoscale/packer-plugin-exoscale
@@ -12,9 +41,9 @@ PACKER_PLUGINS_DIR := $(HOME)/.packer.d/plugins
 # Dependencies
 
 # Requires: https://github.com/exoscale/go.mk
-# - install: git submodule update --init --recursive go.mk
-# - update:  git submodule update --remote
+go.mk/init.mk:
 include go.mk/init.mk
+go.mk/public.mk:
 include go.mk/public.mk
 
 # GoLang


### PR DESCRIPTION
Tested:
```shell
❯ make build
Makefile:54: GoLang versions mismatch (Toolchain: 1.21; go.mod: 1.20)
Cloning into 'go.mk'...
remote: Enumerating objects: 311, done.
remote: Counting objects: 100% (197/197), done.
remote: Compressing objects: 100% (96/96), done.
remote: Total 311 (delta 132), reused 137 (delta 92), pack-reused 114
Receiving objects: 100% (311/311), 62.32 KiB | 554.00 KiB/s, done.
Resolving deltas: 100% (175/175), done.
Makefile:54: GoLang versions mismatch (Toolchain: 1.21; go.mod: 1.20)
mkdir -p '/home/sauterp/src/github.com/exoscale/packer-plugin-exoscale/bin'
'/home/sauterp/bin/go' build \
   \
  -ldflags "-X main.commit=5f68d25 -X main.branch=philippsauter/sc-88913/go-mk-provide-alternative-to-submodule-approach -X main.buildDate=2024-02-22T16:24:31+0000 -X main.version=dev " \
   \
  -o '/home/sauterp/src/github.com/exoscale/packer-plugin-exoscale/bin/packer-plugin-exoscale' \
  '.'
```