### PR TITLE
feat: build arm64 binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
 
 archives:
   - format: zip


### PR DESCRIPTION
This PR adds support for building arm64 binaries.

I'm unable to install the plugin on macOS (M1) as-is.

I built the plugin from source and was able to install it.

I suspect `packer init` looks for `packer-plugin-exoscale_v0.5.1_x5.0_darwin_arm64.zip` but does not find it